### PR TITLE
Pwm set fix

### DIFF
--- a/src/GyverPWM.cpp
+++ b/src/GyverPWM.cpp
@@ -154,7 +154,7 @@ void PWM_resolution(uint8_t pin, uint8_t resolution, uint8_t correct) {
 
 /* Установка заполнения ШИМ сигнала на указанном пине */
 void PWM_set(uint8_t pin, uint16_t duty) {
-  if (duty < 1) {PWM_detach(pin); return;}	// Если заполнение 0 - детачим пин и в LOW
+  if (duty < 1) {PWM_detach(pin); PIN_set(pin, LOW); return;}	// Если заполнение 0 - детачим пин и в LOW
 
   switch (pin) {
     case 3: // Timer2 - B


### PR DESCRIPTION
Не работает `PWM_set` при `duty == 0`. На [странице документации](https://alexgyver.ru/gyverpwm/) нашел ответ, исправляющий ошибку:

![image](https://user-images.githubusercontent.com/24689966/226195966-82b74657-3c71-4167-9d15-e11eab89f896.png)
